### PR TITLE
Fix incorrect parameters to cfg80211_rx_mgmt

### DIFF
--- a/CORE/HDD/src/wlan_hdd_p2p.c
+++ b/CORE/HDD/src/wlan_hdd_p2p.c
@@ -2649,9 +2649,8 @@ void hdd_indicateMgmtFrame( hdd_adapter_t *pAdapter,
     hddLog( LOG1, FL("Indicate Frame over NL80211 Interface"));
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,1,0))
-          cfg80211_rx_mgmt( pAdapter->dev->ieee80211_ptr, pRemainChanCtx->action_pkt_buff.freq, 0,
-                      pRemainChanCtx->action_pkt_buff.frame_ptr,
-                      pRemainChanCtx->action_pkt_buff.frame_length,
+    cfg80211_rx_mgmt( pAdapter->dev->ieee80211_ptr, freq, 0,
+                      pbFrames, nFrameLength,
                       0 );
 #elif (LINUX_VERSION_CODE >= KERNEL_VERSION(3,12,0))
     cfg80211_rx_mgmt( pAdapter->dev->ieee80211_ptr, freq, 0,


### PR DESCRIPTION
Hello Gary,
I fixed a bug on kernel 4.1.
It might be a copy and paste mistake between hdd_remainChanReadyHandler() and hdd_indicateMgmtFrame()  in the commit:
bfbb23eb774f3a1ddf0bb2bcef9681c984822441 Update API to build against 4.1 kernel