### PR TITLE
Fixes for warnings and build errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.a
 *.s
 *.ko
+*.mod
 *.mod.c
 Module.symvers
 modules.order

--- a/CORE/CLD_TXRX/HTT/htt_rx.c
+++ b/CORE/CLD_TXRX/HTT/htt_rx.c
@@ -564,11 +564,13 @@ htt_rx_mpdu_desc_pn_hl(
                 *(word_ptr + 3) = rx_desc->pn_127_96;
                 /* bits 63:0 */
                 *(word_ptr + 2) = rx_desc->pn_95_64;
+                /* fallthrough */
             case 48:
                 /* bits 48:0
                  * copy 64 bits
                  */
                 *(word_ptr + 1) = rx_desc->u0.pn_63_32;
+                /* fallthrough */
             case 24:
                 /* bits 23:0
                  * copy 32 bits

--- a/CORE/HDD/src/wlan_hdd_assoc.c
+++ b/CORE/HDD/src/wlan_hdd_assoc.c
@@ -4788,6 +4788,7 @@ hdd_smeRoamCallback(void *pContext, tCsrRoamInfo *pRoamInfo, tANI_U32 roamId,
                     WLAN_CONTROL_PATH);
                 break;
             }
+            /* fallthrough */
         case eCSR_ROAM_DISASSOCIATED:
             {
                 VOS_TRACE(VOS_MODULE_ID_HDD, VOS_TRACE_LEVEL_INFO,

--- a/CORE/HDD/src/wlan_hdd_tsf.c
+++ b/CORE/HDD/src/wlan_hdd_tsf.c
@@ -44,6 +44,9 @@
 #include <linux/gpio.h>
 int irq_tsf = -1;
 #endif
+
+#include <asm/div64.h>
+
 /**
  * enum hdd_tsf_op_result - result of tsf operation
  *
@@ -665,10 +668,13 @@ static inline uint64_t hdd_get_monotonic_host_time(hdd_context_t *hdd_ctx)
 static inline bool is_target_host_valid(uint64_t delt_host_time,
 					uint64_t delt_target_time)
 {
+	uint64_t delt_host_time_ratio = delt_host_time;
+	do_div(delt_host_time_ratio, 100);
+
 	if ((delt_target_time * HOST_TO_TARGET_TIME_RATIO >
-	    (delt_host_time - delt_host_time/100)) &&
+	    (delt_host_time - delt_host_time_ratio)) &&
 	    (delt_target_time * HOST_TO_TARGET_TIME_RATIO <
-	    (delt_host_time + delt_host_time/100)))
+	    (delt_host_time + delt_host_time_ratio)))
 		return true;
 	else
 		return false;
@@ -773,11 +779,11 @@ static inline int32_t hdd_get_tsf_by_register(hdd_adapter_t *adapter,
 
 	if (!ret && update_target_host_time(adapter))
 		*target_time = adapter->cur_target_time;
-	else
-		*target_time = ((adapter->cur_host_time -
-				adapter->last_host_time) /
-				HOST_TO_TARGET_TIME_RATIO) +
-				adapter->last_target_time;
+	else {
+		uint64_t t = (adapter->cur_host_time - adapter->last_host_time);
+		do_div(t, HOST_TO_TARGET_TIME_RATIO);
+		*target_time = t + adapter->last_target_time;
+	}
 
 	return 0;
 }

--- a/CORE/HDD/src/wlan_hdd_tsf.c
+++ b/CORE/HDD/src/wlan_hdd_tsf.c
@@ -490,6 +490,7 @@ static void hdd_update_timestamp(hdd_adapter_t *adapter,
 		 * If reach MAX_CONTINUOUS_ERROR_CNT, treat it as a
 		 * valid pair
 		 */
+		/* fallthrough */
 	case HDD_TS_STATUS_READY:
 		adapter->last_target_time = adapter->cur_target_time;
 		adapter->last_host_time = adapter->cur_host_time;

--- a/CORE/HDD/src/wlan_hdd_wmm.c
+++ b/CORE/HDD/src/wlan_hdd_wmm.c
@@ -1441,6 +1441,7 @@ static void __hdd_wmm_do_implicit_qos(struct work_struct *work)
       hdd_wmm_free_context(pQosContext);
 
       // fall through and start packets flowing
+      /* fallthrough */
    case SME_QOS_STATUS_SETUP_SUCCESS_NO_ACM_NO_APSD_RSP:
       // no ACM in effect, no need to setup U-APSD
    case SME_QOS_STATUS_SETUP_SUCCESS_APSD_SET_ALREADY:

--- a/CORE/MAC/src/pe/lim/limProcessCfgUpdates.c
+++ b/CORE/MAC/src/pe/lim/limProcessCfgUpdates.c
@@ -490,6 +490,7 @@ limHandleCFGparamUpdate(tpAniSirGlobal pMac, tANI_U32 cfgId)
                 }
             }
         }
+        /* fallthrough */
     case WNI_CFG_MAX_PS_POLL:
     case WNI_CFG_NUM_BEACON_PER_RSSI_AVERAGE:
     case WNI_CFG_MIN_RSSI_THRESHOLD:

--- a/CORE/MAC/src/pe/lim/limProcessSmeReqMessages.c
+++ b/CORE/MAC/src/pe/lim/limProcessSmeReqMessages.c
@@ -6268,8 +6268,10 @@ limProcessSmeReqMessages(tpAniSirGlobal pMac, tpSirMsgQ pMsg)
              * Do not add BREAK here
              */
 #ifdef FEATURE_OEM_DATA_SUPPORT
+            /* fallthrough */
         case eWNI_SME_OEM_DATA_REQ:
 #endif
+            /* fallthrough */
         case eWNI_SME_JOIN_REQ:
             /* If we have an existing P2P GO session we need to insert NOA before actually process this SME Req */
             if (!pMac->fScanOffload && (limIsNOAInsertReqd(pMac) == TRUE) &&

--- a/CORE/SAP/src/sapFsm.c
+++ b/CORE/SAP/src/sapFsm.c
@@ -3134,7 +3134,7 @@ sapGotoStarting
     if (eHAL_STATUS_SUCCESS != halStatus)
         VOS_TRACE(VOS_MODULE_ID_SAP, VOS_TRACE_LEVEL_ERROR,
         "%s: Failed to issue sme_RoamConnect", __func__);
-        return halStatus;
+    return halStatus;
 
 }// sapGotoStarting
 

--- a/CORE/SAP/src/sapModule.c
+++ b/CORE/SAP/src/sapModule.c
@@ -3832,19 +3832,19 @@ WLANSAP_ResetSapConfigAddIE(tsap_Config_t *pConfig,
         pConfig->probeRespIEsBufferLen = 0;
         pConfig->pProbeRespIEsBuffer = NULL;
         if(eUPDATE_IE_ALL != updateType)  break;
-
+        /* fallthrough */
     case eUPDATE_IE_ASSOC_RESP:
         vos_mem_free( pConfig->pAssocRespIEsBuffer);
         pConfig->assocRespIEsLen = 0;
         pConfig->pAssocRespIEsBuffer = NULL;
         if(eUPDATE_IE_ALL != updateType)  break;
-
+        /* fallthrough */
     case eUPDATE_IE_PROBE_BCN:
         vos_mem_free(pConfig->pProbeRespBcnIEsBuffer );
         pConfig->probeRespBcnIEsLen = 0;
         pConfig->pProbeRespBcnIEsBuffer = NULL;
         if(eUPDATE_IE_ALL != updateType)  break;
-
+        /* fallthrough */
     default:
         if(eUPDATE_IE_ALL != updateType)
             VOS_TRACE( VOS_MODULE_ID_SAP, VOS_TRACE_LEVEL_ERROR,

--- a/CORE/SERVICES/BMI/ol_fw.c
+++ b/CORE/SERVICES/BMI/ol_fw.c
@@ -2347,6 +2347,7 @@ A_STATUS ol_fw_populate_clk_settings(A_refclk_speed_t refclk,
 		clock_s->wlan_pll.outdiv = 0;
 		clock_s->pll_settling_time = 1024;
 		clock_s->refclk_hz = 0;
+		/* fallthrough */
 	default:
 		return A_ERROR;
 	}

--- a/CORE/SME/src/QoS/sme_Qos.c
+++ b/CORE/SME/src/QoS/sme_Qos.c
@@ -4967,6 +4967,7 @@ eHalStatus sme_QosProcessHandoffAssocReqEv(tpAniSirGlobal pMac, v_U8_t sessionId
             }
 #endif
 
+            /* fallthrough */
          case SME_QOS_CLOSED:
          case SME_QOS_INIT:
          default:
@@ -7249,6 +7250,7 @@ eHalStatus sme_QosAddTsFailureFnp(tpAniSirGlobal pMac, tListElem *pEntry)
       break;
    case SME_QOS_REASON_MODIFY:
       flow_info->reason = SME_QOS_REASON_REQ_SUCCESS;
+      /* fallthrough */
    case SME_QOS_REASON_REQ_SUCCESS:
    default:
       inform_hdd = VOS_FALSE;
@@ -7472,6 +7474,7 @@ eHalStatus sme_QosAddTsSuccessFnp(tpAniSirGlobal pMac, tListElem *pEntry)
    case SME_QOS_REASON_REQ_SUCCESS:
       hdd_status = SME_QOS_STATUS_SETUP_MODIFIED_IND;
       inform_hdd = VOS_TRUE;
+      /* fallthrough */
    default:
       delete_entry = VOS_FALSE;
       break;

--- a/CORE/SME/src/csr/csrApiRoam.c
+++ b/CORE/SME/src/csr/csrApiRoam.c
@@ -13592,6 +13592,7 @@ static void csrRoamGetBssStartParms(tpAniSirGlobal pMac,
 	default:
 		smsLog(pMac, LOGE, FL("sees an unknown pSirNwType (%d)"),
 				nwType);
+        /* fallthrough */
 	case eSIR_11A_NW_TYPE:
 		csr_populate_default_rates(opr_rates, true, true);
 		if (eCSR_OPERATING_CHANNEL_ANY != operation_channel) {
@@ -19820,6 +19821,7 @@ eHalStatus csrPsOffloadIsFullPowerNeeded(tpAniSirGlobal pMac,
                     case eCsrForcedDisassoc:
                     case eCsrForcedDisassocMICFailure:
                         reason = eSME_LINK_DISCONNECTED_BY_HDD;
+                        /* fallthrough */
                     case eCsrSmeIssuedDisassocForHandoff:
                     case eCsrForcedDeauth:
                     case eCsrHddIssuedReassocToSameAP:

--- a/CORE/SME/src/csr/csrApiRoam.c
+++ b/CORE/SME/src/csr/csrApiRoam.c
@@ -18916,7 +18916,7 @@ eHalStatus csrRoamOffloadScan(tpAniSirGlobal pMac, tANI_U8 sessionId,
                        vos_nv_getChannelEnabledState(*ChannelList),
                        *ChannelList,
                        num_channels);
-              ChannelList++;
+            ChannelList++;
         }
         pRequestBuf->ConnectedNetwork.ChannelCount = num_channels;
         /* If the profile changes as to what it was earlier, inform the

--- a/CORE/SME/src/csr/csrNeighborRoam.c
+++ b/CORE/SME/src/csr/csrNeighborRoam.c
@@ -5098,6 +5098,7 @@ eHalStatus csrNeighborRoamIndicateDisconnect(tpAniSirGlobal pMac,
         case eCSR_NEIGHBOR_ROAM_STATE_PREAUTH_DONE:
             /* Stop pre-auth to reassoc interval timer */
             vos_timer_stop(&pSession->ftSmeContext.preAuthReassocIntvlTimer);
+            /* fallthrough */
         case eCSR_NEIGHBOR_ROAM_STATE_REPORT_SCAN:
         case eCSR_NEIGHBOR_ROAM_STATE_PREAUTHENTICATING:
             csr_neighbor_roam_state_transition(pMac,
@@ -5271,6 +5272,7 @@ eHalStatus csrNeighborRoamIndicateConnect(tpAniSirGlobal pMac,
                 break;
             }
             /* Fall through if the status is SUCCESS */
+            /* fallthrough */
         case eCSR_NEIGHBOR_ROAM_STATE_INIT:
             /* Reset all the data structures here */
             csrNeighborRoamResetInitStateControlInfo(pMac, sessionId);

--- a/CORE/SME/src/pmc/pmc.c
+++ b/CORE/SME/src/pmc/pmc.c
@@ -3127,6 +3127,7 @@ eHalStatus pmcOffloadEnableStaPsHandler(tpAniSirGlobal pMac,
              */
              smsLog(pMac, LOGE, FL("Fail to issue eSmeCommandEnterBmps"));
          }
+         /* fallthrough */
        case eHAL_STATUS_PMC_NOT_NOW:
          /*
           * Some module voted against Power Save.

--- a/CORE/VOSS/src/vos_sched.c
+++ b/CORE/VOSS/src/vos_sched.c
@@ -1153,15 +1153,16 @@ VosWDThread
     {
       /* Post Msg to detect thread stuck */
       if (test_and_clear_bit(WD_WLAN_DETECT_THREAD_STUCK,
-                                   &pWdContext->wdEventFlag)) {
+                                   &pWdContext->wdEventFlag))
+      {
 
-       if (gpVosSchedContext &&
-           !test_bit(MC_SUSPEND_EVENT, &gpVosSchedContext->mcEventFlag))
-            vos_wd_detect_thread_stuck();
-       else
-            VOS_TRACE(VOS_MODULE_ID_VOSS, VOS_TRACE_LEVEL_INFO,
-               "%s: controller thread %s id: %d is suspended do not attemp probing",
-               __func__, current->comm, current->pid);
+        if (gpVosSchedContext &&
+            !test_bit(MC_SUSPEND_EVENT, &gpVosSchedContext->mcEventFlag))
+          vos_wd_detect_thread_stuck();
+        else
+          VOS_TRACE(VOS_MODULE_ID_VOSS, VOS_TRACE_LEVEL_INFO,
+                    "%s: controller thread %s id: %d is suspended do not attemp probing",
+                    __func__, current->comm, current->pid);
         /*
          * Process here and return without processing any SSR
          * related logic.


### PR DESCRIPTION
We're using the qcacld-2.0 driver to support the wifi module on our SanCloud BBE Extended WiFi boards. We found some initial build issues when trying to use the upstream code from [the qcacld-2.0 Code Aurora repository](https://source.codeaurora.org/quic/la/platform/vendor/qcom-opensource/wlan/qcacld-2.0/) in our Yocto Project builds and found the Boundary Devices repository here already had fixes for most of these. We've since added additional fixes for a build error (use of plain 64-bit division in wlan_hdd_tsf.c), several warnings (fallthrough in switch statements, misleading indentation) and the git ignore list (*.mod files should be ignored).

Rather than keep these fixes in our own repo and rebase each time there's an update, we'd like to merge them as far upstream as possible. Since the fixes in the Boundary Devices repo here haven't yet been pushed to the Code Aurora repository I think it's best that we submit our additional fixes here. Please let me know if this is the best approach to collaborate here so that we don't duplicate effort.